### PR TITLE
Added historical var

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -114,11 +114,10 @@ function moveWorkoutUp(workout) {
 }
 
 function openTracker(workout, source='') {
+  historical = false;
   if (source === 'history') {
     historical = true;
-  } else {
-    historical = false;
-  }
+  } 
   state.page.value = types.pageTypes.Tracker
   state.trackedWorkout.value = workout
 }

--- a/src/App.vue
+++ b/src/App.vue
@@ -15,6 +15,8 @@ const state = {
     trackedWorkout: ref(),
 }
 
+let historical = false;
+
 // persist state -- eventually this will be stored in database
 watchEffect(() => {
   localStorage.setItem('workouts', JSON.stringify(state.workouts.value))
@@ -111,7 +113,12 @@ function moveWorkoutUp(workout) {
   }
 }
 
-function openTracker(workout) {
+function openTracker(workout, source='') {
+  if (source === 'history') {
+    historical = true;
+  } else {
+    historical = false;
+  }
   state.page.value = types.pageTypes.Tracker
   state.trackedWorkout.value = workout
 }
@@ -153,6 +160,7 @@ function signout() {
     />
     <Tracker v-else-if="state.page.value === types.pageTypes.Tracker"
         :workout = "state.trackedWorkout.value"
+        :historical="historical"
         @click-back="closeTracker"
         @add-exercise="addExercise"
         @del-exercise="delExercise"

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -4,7 +4,7 @@ import { ref, computed } from 'vue'
 
 const props = defineProps(['workouts', 'user']);
 
-console.log(`prop: user = ${JSON.stringify(props.user)}`);
+// console.log(`prop: user = ${JSON.stringify(props.user)}`);
 
 const emit = defineEmits([
   'addWorkout', 

--- a/src/components/Tracker.vue
+++ b/src/components/Tracker.vue
@@ -2,7 +2,10 @@
 
   import { ref, computed } from 'vue'
 
-  defineProps(['workout'])
+  const props = defineProps(['workout', 'historical']);
+  
+  // TODO: remove this debug statemnet
+  console.log(`value of prop historical = ${props.historical}`);
 
   const emit = defineEmits([
     'click-back', 
@@ -66,6 +69,8 @@
     selectedMonth.value = Object.keys(months).find(key => months[key] === now.getMonth());
     selectedDay.value = now.getDate();
   }
+
+  
 
 </script>
 


### PR DESCRIPTION
Added `historical` var to App.vue with a `let` declaration (not a `ref`). If the call to open tracker comes from the (as of now, yet-to-be-implemented) history component, `historical` is set to `true` and passed to the tracker. Otherwise, `false` is passed to the tracker. The tracker uses it to determine behavior of Firebase transactions on certain events.

Closes #37 