### PR TITLE
Created cached deep copy of workout prop

### DIFF
--- a/src/components/Tracker.vue
+++ b/src/components/Tracker.vue
@@ -42,6 +42,8 @@
     return editing.value ? 'Done' : 'Edit Exercises'
   })
 
+  const cached = JSON.parse(JSON.stringify(props.workout));
+
   function addExercise() {
     const value = newExercise.value
     emit('addExercise', value)


### PR DESCRIPTION
Closes #38 

Created a deep copy of the `workout` prop passed to the Tracker component. Deep copy was made by serializing the object with `JSON.stringify` and then converting back to a JS object with `JSON.parse`.