### PR TITLE
Tracker Save button writes workout to History doc

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -137,11 +137,15 @@ function openTracker(workout, source='') {
 
 function closeTracker() {
   state.page.value = types.pageTypes.Home
-  state.trackedWorkout.value = null
+  // state.trackedWorkout.value = null
 }
 
 function writeCurrentWorkouts() {
   firebase.writeCurrentWorkouts(user.email, state.workouts.value);
+}
+
+function writeWorkoutToHistory() {
+  firebase.writeWorkoutToHistory(user.email, state.trackedWorkout.value);
 }
 
 function signout() {
@@ -173,7 +177,7 @@ function signout() {
         @move-exercise-down="moveExerciseDown"
         @add-set="addSet"
         @del-set="delSet"
-        @save-tracked-workout="saveWorkouts"
+        @save-to-history="writeWorkoutToHistory"
     />
   </div>
 </template>

--- a/src/components/Tracker.vue
+++ b/src/components/Tracker.vue
@@ -12,7 +12,7 @@
     'moveExerciseDown',
     'addSet',
     'delSet',
-    'saveTrackedWorkout',
+    'saveToHistory',
   ])
 
   const startYear = 2000;
@@ -185,7 +185,7 @@
         <button @click="editing = !editing">{{ editBtnMsg }}</button>
       </div>
       <div class="row">
-        <button @click="$emit('saveTrackedWorkout'); $emit('click-back')">Save to History</button>
+        <button @click="$emit('saveToHistory'); $emit('click-back')">Save to History</button>
       </div>
     </section>
   </div>


### PR DESCRIPTION
Closes #39 

Clicking on the 'Save To History' button in the Tracker component triggers writes with array union (i.e. appends) the tracked workout to the 'History' document in Firebase.

If the initial update of 'History' doc fails, it appears that Firebase logs a 404 error to the console, which cannot be avoided/caught on the client side. The function will then check to see if the doc exists, create it if necessary, and then write the workout, all with appropriate error handling.