### PR TITLE
Date select inputs on Tracker page alter Workout object

### DIFF
--- a/src/components/Tracker.vue
+++ b/src/components/Tracker.vue
@@ -51,6 +51,11 @@
     return [...Array(numDaysInMonth).keys()].map(d => d+1);
   }
 
+  function saveToHistory() {
+    props.workout.date = new Date(selectedYear.value, types._months[selectedMonth.value], selectedDay.value);
+    emit('saveToHistory');
+  }
+
   function today() {
     const now = new Date();
     selectedYear.value = now.getFullYear();
@@ -171,7 +176,7 @@
         <button @click="editing = !editing">{{ editBtnMsg }}</button>
       </div>
       <div class="row">
-        <button @click="$emit('saveToHistory'); $emit('close-tracker')">Save to History</button>
+        <button @click="saveToHistory(); $emit('close-tracker')">Save to History</button>
       </div>
     </section>
   </div>


### PR DESCRIPTION
Closes #53 

I forgot to implement this earlier, so when the user changed the date, it would not change the Workout object and therefore would not be updated in Firebase. This has been fixed.